### PR TITLE
Add more highlighting support and stylesheet.

### DIFF
--- a/grammars/powershell.cson
+++ b/grammars/powershell.cson
@@ -11,7 +11,6 @@
 'foldingStopMarker': '^\\s*\\}|^\\s*\\]|^\\s*\\)|^\\s*"""\\s*$'
 'patterns': [
   {
-
     'captures':
       '1':
         'name': 'punctuation.variable.begin.powershell'
@@ -654,6 +653,16 @@
         'include': 'source.regexp.powershell'
       }
     ]
+  'embedded-variable' :
+    'patterns': [
+      {
+        'captures':
+          '1':
+            'name': 'embedded.punctuation.variable.begin.powershell'
+        'match': '(\\$)[a-zA-Z_][a-zA-Z0-9_]*?\\b'
+        'name': 'embedded.variable.other.powershell'
+      }
+    ]
   'string_quoted_double':
     'patterns': [
       {
@@ -751,6 +760,9 @@
           }
           {
             'include': '#escaped_char'
+          }
+          {
+            'include': '#embedded-variable'
           }
         ]
       }

--- a/spec/powershell-spec.coffee
+++ b/spec/powershell-spec.coffee
@@ -37,3 +37,46 @@ describe "PowerShell grammar", ->
       {tokens} = grammar.tokenizeLine("$var")
       expect(tokens[0]).toEqual value: "$", scopes: ["source.powershell", "variable.other.powershell", "punctuation.variable.begin.powershell"]
       expect(tokens[1]).toEqual value: "var", scopes: ["source.powershell", "variable.other.powershell"]
+
+  describe "Double-quoted strings", ->
+    describe "Highlight normal double-quoted string", ->
+      tokens = null
+
+      beforeEach ->
+        {tokens} = grammar.tokenizeLine("\"Hi there! and welcome to 'string-making': 101.\"")
+
+      it "should tag the opening double-quote", ->
+        expect(tokens[0]).toEqual value: "\"", scopes: ["source.powershell", "string.quoted.double.single-line.powershell", "punctuation.definition.string.begin.powershell"]
+
+      it "should tag content of the string", ->
+        expect(tokens[1]).toEqual value: "Hi there! and welcome to 'string-making': 101.", scopes: ["source.powershell", "string.quoted.double.single-line.powershell"]
+
+      it "should tag the closing double-quote", ->
+        expect(tokens[2]).toEqual value: "\"", scopes: ["source.powershell", "string.quoted.double.single-line.powershell", "punctuation.definition.string.end.powershell"]
+
+    describe "Highlight empty string", ->
+      tokens = null
+
+      beforeEach ->
+        {tokens} = grammar.tokenizeLine("\"\"")
+
+      it "should tag the opening double-quote", ->
+        expect(tokens[0]).toEqual value: "\"", scopes: ["source.powershell", "string.quoted.double.single-line.powershell", "punctuation.definition.string.begin.powershell"]
+
+      it "should tag the closing double-quote as empty string", ->
+        expect(tokens[1]).toEqual value: "\"", scopes: ["source.powershell", "string.quoted.double.single-line.powershell", "punctuation.definition.string.end.powershell", "meta.empty-string.double.powershell"]
+
+    describe "Highlight Powershell variables within the string", ->
+      tokens = null
+
+      beforeEach ->
+        {tokens} = grammar.tokenizeLine("\"Hi there $name\"")
+
+      it "should tag content", ->
+        expect(tokens[1]).toEqual value: "Hi there ", scopes: ["source.powershell", "string.quoted.double.single-line.powershell"]
+
+      it "should tag the beginning of variable names", ->
+        expect(tokens[2]).toEqual value: "$", scopes: ["source.powershell", "string.quoted.double.single-line.powershell", "embedded.variable.other.powershell", "embedded.punctuation.variable.begin.powershell"]
+
+      it "should tag variable names", ->
+        expect(tokens[3]).toEqual value: "name", scopes: ["source.powershell", "string.quoted.double.single-line.powershell", "embedded.variable.other.powershell"]

--- a/stylesheets/obsidian.less
+++ b/stylesheets/obsidian.less
@@ -39,6 +39,14 @@
       color: @obsidian-purple;
     }
 
+    .embedded.punctuation.variable.begin {
+      color: @obsidian-light;
+    }
+
+    .embedded.variable.other {
+      color: @obsidian-white;
+    }
+
     .punctuation.variable.begin {
       color: @obsidian-yellow;
     }


### PR DESCRIPTION
The stylesheet changes are non-functional essentially they introduce a default stylesheet for Powershell based on the popular "Son-Of-Obsidian: theme for Visual Studio. These commits can be ignored if required.

The other changes in this pull request include:
- Adding more comparison operators, `-gt`,`-lt` and explicitly case-insensitive `-ieq` and case-sensitive `-ceq` equals operators.
- Adding support for highlighting the `$` as part of the variable name which didn't appear to work previously.
- Adding support for highlighting variables within double-quoted strings (where the variable will be expanded).
- Adding support for highlighting the `#` at the beginning of single line comments separately from the comment text.
