### PR TITLE
Add escaped variables to the grammar

### DIFF
--- a/grammars/powershell.cson
+++ b/grammars/powershell.cson
@@ -20,7 +20,7 @@
     'name':'storage.type.powershell'
   }
   {
-    'match': '(`n)|(`")|(`\')|(`a)|(`b)|(`r)|(`t)|(`f)|(`0)|(`v)|(--%)|(``)'
+    'match': '(`n)|(`")|(`\\$)|(`\')|(`a)|(`b)|(`r)|(`t)|(`f)|(`0)|(`v)|(--%)|(``)'
     'name': 'constant.character.escape.powershell'
   }
   {

--- a/spec/powershell-spec.coffee
+++ b/spec/powershell-spec.coffee
@@ -305,3 +305,8 @@ describe "PowerShell grammar", ->
         expect(tokens[1]).toHaveScopes ["storage.type.powershell"]
         expect(tokens[2].value).toEqual "]"
         expect(tokens[2]).toHaveScopes ["punctuation.storage.type.end.powershell"]
+
+  describe "Escaped variables", ->
+    it "escapes variables", ->
+      {tokens} = grammar.tokenizeLine("`$a")
+      expect(tokens[0]).toHaveScopes["constant.character.escape.powershell"]


### PR DESCRIPTION
Writing this down for my own reference later (i'm guessing you already know most of this.

Powershell allows for escaping the dollar sign from the docs on [about_Escape_Characters](http://technet.microsoft.com/en-us/library/hh847755.aspx). Look under the `ESCAPING A VARIABLE` section.
