### PR TITLE
Fix line continuations and escapes

### DIFF
--- a/grammars/powershell.cson
+++ b/grammars/powershell.cson
@@ -20,7 +20,7 @@
     'name':'storage.type.powershell'
   }
   {
-    'match': '(`n)|(`")|(`\\$)|(`\')|(`a)|(`b)|(`r)|(`t)|(`f)|(`0)|(`v)|(--%)|(``)'
+    'match': '(`n)|(`")|(`\\$)|(`\')|(`a)|(`b)|(`r)|(`t)|(`f)|(`0)|(`v)|(--%)|(``)|(`\\S)'
     'name': 'constant.character.escape.powershell'
   }
   {

--- a/spec/powershell-spec.coffee
+++ b/spec/powershell-spec.coffee
@@ -306,10 +306,15 @@ describe "PowerShell grammar", ->
         expect(tokens[2].value).toEqual "]"
         expect(tokens[2]).toHaveScopes ["punctuation.storage.type.end.powershell"]
 
-  describe "Escaped variables", ->
+  describe "Escape characters", ->
+
     it "escapes variables", ->
       {tokens} = grammar.tokenizeLine("`$a")
-      expect(tokens[0]).toHaveScopes["constant.character.escape.powershell"]
+      expect(tokens[0]).toHaveScopes ["constant.character.escape.powershell"]
+
+    it "escapes any character", ->
+      {tokens} = grammar.tokenizeLine("`_")
+      expect(tokens[0]).toHaveScopes ["source.powershell", "constant.character.escape.powershell"]
 
   describe "Line continuations", ->
 


### PR DESCRIPTION
Let's try this again shall we? "Continuation" (:wink:) of #19 and #14.

Looks better this time around @choque:

![image](https://cloud.githubusercontent.com/assets/238079/4494478/54b7862c-4a52-11e4-9a02-7fdd1b6ccfc4.png)
