### PR TITLE
Fix escaped quotes in a string from being recognized incorrectly

### DIFF
--- a/grammars/powershell.cson
+++ b/grammars/powershell.cson
@@ -11,6 +11,9 @@
 'foldingStopMarker': '^\\s*\\}|^\\s*\\]|^\\s*\\)|^\\s*"""\\s*$'
 'patterns': [
   {
+    'include': '#escaped_char'
+  }
+  {
     'captures':
       '1':
         'name': 'punctuation.storage.type.begin.powershell'
@@ -18,10 +21,6 @@
         'name': 'punctuation.storage.type.end.powershell'
     'match':'(\\[)([A-Za-z0-9_\\.]+)(\\])'
     'name':'storage.type.powershell'
-  }
-  {
-    'match': '(`n)|(`")|(`\\$)|(`\')|(`a)|(`b)|(`r)|(`t)|(`f)|(`0)|(`v)|(--%)|(``)|(`\\S)'
-    'name': 'constant.character.escape.powershell'
   }
   {
     'captures':
@@ -483,6 +482,9 @@
   }
 ]
 'repository':
+  'escaped_char':
+    'match': '(`n)|(`")|(`\\$)|(`\')|(`a)|(`b)|(`r)|(`t)|(`f)|(`0)|(`v)|(--%)|(``)|(`\\S)'
+    'name': 'constant.character.escape.powershell'
   'constant_placeholder':
     'match': '(?i:%(\\([a-z_]+\\))?#?0?\\-?[ ]?\\+?([0-9]*|\\*)(\\.([0-9]*|\\*))?[hL]?[a-z%])'
     'name': 'constant.other.placeholder.powershell'
@@ -790,5 +792,8 @@
       }
       {
         'include': '#string_quoted_single'
+      }
+      {
+        'include': '#escaped_char'
       }
     ]

--- a/spec/powershell-spec.coffee
+++ b/spec/powershell-spec.coffee
@@ -110,8 +110,12 @@ describe "PowerShell grammar", ->
         expect(tokens[3]).toHaveScopes ["embedded.variable.other.powershell"]
 
       it "should not tokenize as a variable when leading $ has been escaped", ->
-        expect(tokens[4].value).toEqual " `$bob"
-        expect(tokens[4]).not.toHaveScopes expectedDollarSignScopes
+        expect(tokens[5].value).toEqual "`$"
+        expect(tokens[5]).toHaveScopes ["source.powershell", "string.quoted.double.single-line.powershell", "constant.character.escape.powershell"]
+        expect(tokens[5]).not.toHaveScopes ["embedded.variable.other.powershell"]
+
+        expect(tokens[6].value).toEqual "bob"
+        expect(tokens[6]).not.toHaveScopes ["embedded.variable.other.powershell"]
 
   describe "Keywords", ->
     describe "Block keywords", ->


### PR DESCRIPTION
From issue #22.
