### PR TITLE
Fix comparison operator matching

### DIFF
--- a/grammars/powershell.cson
+++ b/grammars/powershell.cson
@@ -42,7 +42,7 @@
     'name': 'keyword.operator.bitwise.powershell'
   }
   {
-    'match': '-eq|-ceq|-ieq|-lt|-gt|-le|-ge|-ne|-notlike|-like|-match|-notmatch|-contains|-notcontains|-in|-notin|-replace'
+    'match': '\\B(?i:(-eq|-ceq|-ieq|-lt|-gt|-le|-ge|-ne|-notlike|-like|-match|-notmatch|-contains|-notcontains|-in|-notin|-replace))\\b'
     'name': 'keyword.operator.comparison.powershell'
   }
   {

--- a/spec/powershell-spec.coffee
+++ b/spec/powershell-spec.coffee
@@ -226,6 +226,11 @@ describe "PowerShell grammar", ->
           {tokens} = grammar.tokenizeLine operator
           expect(tokens[0]).toEqual value: operator, scopes: ["source.powershell","keyword.operator.comparison.powershell"]
 
+      it "tokenizes comparison operators regardless of case", ->
+        for operator in comparisonOperators
+          {tokens} = grammar.tokenizeLine operator.toUpperCase()
+          expect(tokens[0]).toEqual value: operator.toUpperCase(), scopes: ["source.powershell","keyword.operator.comparison.powershell"]
+
       it "will not tokenize the operators if there's more characters", ->
         for operator in comparisonOperators
           operatorPlus = operator + "ual"


### PR DESCRIPTION
This fixes 2 issues with powershell comparison operators matching in the grammar:
1. The operators were being highlighted if they were part of a word (from issue #26)
2. The operators currently only match if what's typed is lower-case, but they should be case-insensitive.

These commits seem to get the word boundary stuff working:

![image](https://cloud.githubusercontent.com/assets/238079/5188539/d5e8686c-74a3-11e4-829f-106ac469e1bb.png)

Before, `-equal` would have `-eq` highlighted but not the rest of the word.

[Comparison operators PowerShell reference](http://technet.microsoft.com/en-us/library/hh847759.aspx)
