### PR TITLE
Remove `illegal_names`

### DIFF
--- a/grammars/powershell.cson
+++ b/grammars/powershell.cson
@@ -497,9 +497,6 @@
         'end': '(?![A-Za-z0-9_])'
         'patterns': [
           {
-            'include': '#illegal_names'
-          }
-          {
             'include': '#generic_names'
           }
         ]
@@ -509,9 +506,6 @@
         'end': '(?![A-Za-z0-9_])'
         'patterns': [
           {
-            'include': '#illegal_names'
-          }
-          {
             'include': '#generic_names'
           }
         ]
@@ -520,17 +514,11 @@
   'entity_name_class':
     'patterns': [
       {
-        'include': '#illegal_names'
-      }
-      {
         'include': '#generic_names'
       }
     ]
   'entity_name_function':
     'patterns': [
-      {
-        'include': '#illegal_names'
-      }
       {
         'include': '#generic_names'
       }
@@ -543,9 +531,6 @@
     ]
   'generic_names':
     'match': '[A-Za-z_][A-Za-z0-9_]*'
-  'illegal_names':
-    'match': '\\b(and|as|assert|break|class|continue|def|del|elif|else|except|exec|finally|for|global|if|import|in|is|lambda|not|or|pass|print|raise|return|try|while|with|yield)\\b'
-    'name': 'invalid.illegal.name.powershell'
   'keyword_arguments':
     'begin': '\\b([a-zA-Z_][a-zA-Z_0-9]*)\\s*(=)(?!=)'
     'beginCaptures':


### PR DESCRIPTION
i think i'd like to remove these until i have found good reasoning _for_
having them in this grammar definition.
