### PR TITLE
fixed .DESCRIPTION prefix

### DIFF
--- a/snippets/language-powershell.cson
+++ b/snippets/language-powershell.cson
@@ -12,7 +12,7 @@
     'prefix': 'new'
     'body': 'New-Object'
   '.DESCRIPTION':
-    'prefix': '.s'
+    'prefix': '.d'
     'body': '.DESCRIPTION\n'
   '.EXAMPLE':
     'prefix': '.e'


### PR DESCRIPTION
**.s** prefix was used with both .DESCRIPTION and .SYNOPSIS.  Updated .DESCRIPTION prefix to **.d**